### PR TITLE
[screensaver.asterwave] bump to 3.1.0

### DIFF
--- a/screensaver.asterwave/addon.xml.in
+++ b/screensaver.asterwave/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <addon
   id="screensaver.asterwave"
-  version="3.0.3"
+  version="3.1.0"
   name="AsterWave"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
Due to https://github.com/xbmc/xbmc/pull/16444 and GUI API breakage, a version bump is required