### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This is a [Kodi](https://kodi.tv) screensaver addon.
 
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build and run tests](https://github.com/xbmc/screensaver.asterwave/actions/workflows/build.yml/badge.svg?branch=Matrix)](https://github.com/xbmc/screensaver.asterwave/actions/workflows/build.yml)
-[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.screensaver.asterwave?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=41&branchName=Matrix)
-[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/screensaver.asterwave/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fscreensaver.asterwave/branches/)
-<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/screensaver.asterwave?branch=Matrix&svg=true)](https://ci.appveyor.com/project/xbmc/screensaver-asterwave?branch=Matrix) -->
+[![Build and run tests](https://github.com/xbmc/screensaver.asterwave/actions/workflows/build.yml/badge.svg?branch=Nexus)](https://github.com/xbmc/screensaver.asterwave/actions/workflows/build.yml)
+[![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.screensaver.asterwave?branchName=Nexus)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=41&branchName=Nexus)
+[![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/screensaver.asterwave/job/Nexus/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fscreensaver.asterwave/branches/)
+<!--- [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/screensaver.asterwave?branch=Nexus&svg=true)](https://ci.appveyor.com/project/xbmc/screensaver-asterwave?branch=Nexus) -->
 
 ## Build instructions
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
   branches:
     include:
     - Matrix
+    - Nexus
     - releases/*
   paths:
     include:

--- a/screensaver.asterwave/addon.xml.in
+++ b/screensaver.asterwave/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <addon
   id="screensaver.asterwave"
-  version="3.3.0"
+  version="20.0.0"
   name="AsterWave"
   provider-name="Team Kodi">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This change the builds to final released Kodi Matrix.

Further is the version to 19.0.0 increased to have equal to Kodi and to see on which Version this addon works.